### PR TITLE
ci: skip code owners on lockfiles and workflows; automerge Renovate deps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*             @adamdecaf
+
+# Lockfiles have no owners so dependency-only PRs skip code-owner review.
+go.mod
+go.sum
+**/go.mod
+**/go.sum
+Gemfile.lock
+**/Gemfile.lock
+
+# GitHub Actions workflows have no owners so action-only PRs skip code-owner review.
+.github/workflows/**

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,24 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "description": "Automerge GitHub Actions updates (including majors)",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Keep docker/image majors out of grouped update-all PRs and do not automerge them",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "docker major",
+      "automerge": false
     }
   ],
   "platformAutomerge": true


### PR DESCRIPTION
Keep the catch-all CODEOWNERS entry. Lockfiles (`go.mod` / `go.sum` and others that exist) and `.github/workflows/**` are left without owners (last-match-wins) so dependency-only PRs do not request a code-owner review.

Renovate: automerge minor/patch/pin/digest and GitHub Actions updates (including action majors) with platformAutomerge. Docker/image majors are split into their own group and not auto-merged.